### PR TITLE
Use visionOS SDK instead iOS SDK.

### DIFF
--- a/App/App.xcodeproj/project.pbxproj
+++ b/App/App.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		D583D7CA2B9B634800B94F73 /* ClipApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D583D7C92B9B634800B94F73 /* ClipApp.swift */; };
 		D583D7CE2B9B634B00B94F73 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D583D7CD2B9B634B00B94F73 /* Assets.xcassets */; };
 		D583D7D12B9B634B00B94F73 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D583D7D02B9B634B00B94F73 /* Preview Assets.xcassets */; };
-		D583D7D62B9B634B00B94F73 /* Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = D583D7C72B9B634800B94F73 /* Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		D583D7D62B9B634B00B94F73 /* Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = D583D7C72B9B634800B94F73 /* Clip.app */; platformFilters = (ios, macos, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D583D7DC2B9B639900B94F73 /* AppFeature in Frameworks */ = {isa = PBXBuildFile; productRef = D583D7DB2B9B639900B94F73 /* AppFeature */; };
 /* End PBXBuildFile section */
 
@@ -273,6 +273,10 @@
 /* Begin PBXTargetDependency section */
 		D583D7D52B9B634B00B94F73 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				macos,
+			);
 			target = D583D7C62B9B634800B94F73 /* Clip */;
 			targetProxy = D583D7D42B9B634B00B94F73 /* PBXContainerItemProxy */;
 		};
@@ -439,12 +443,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = jp.tryswift.tokyo.App;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
 		};
@@ -484,12 +488,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = jp.tryswift.tokyo.App;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Release;
 		};

--- a/MyLibrary/Package.swift
+++ b/MyLibrary/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "MyLibrary",
   defaultLocalization: "en",
-  platforms: [.iOS(.v17), .macOS(.v14), .watchOS(.v10), .tvOS(.v17)],
+  platforms: [.iOS(.v17), .macOS(.v14), .watchOS(.v10), .tvOS(.v17), .visionOS(.v1)],
   products: [
     .library(
       name: "AppFeature",

--- a/MyLibrary/Sources/Safari/Safari.swift
+++ b/MyLibrary/Sources/Safari/Safari.swift
@@ -51,31 +51,3 @@ public struct SafariViewRepresentation: UIViewControllerRepresentable {
   public func makeCoordinator() {
   }
 }
-
-public extension View {
-  func safari<T: Identifiable & Equatable, V: View>(
-    item: Binding<T?>,
-    sheetContent: @escaping (T) -> V,
-    action: @escaping (T) -> Void
-  ) -> some View {
-    self.modifier(SafariModifier(item: item, sheetContent: sheetContent, action: action))
-  }
-}
-
-struct SafariModifier<T: Identifiable & Equatable, V: View>: ViewModifier {
-  let item: Binding<T?>
-  let sheetContent: (T) -> V
-  let action: (T) -> Void
-  
-  func body(content: Content) -> some View {
-    content
-      #if os(iOS) || os(macOS)
-      .sheet(item: item, content: sheetContent)
-      #elseif os(visionOS)
-      .onChange(of: item.wrappedValue) { _, newValue in
-        guard let newValue else { return }
-        action(newValue)
-      }
-      #endif
-  }
-}

--- a/MyLibrary/Sources/Safari/Safari.swift
+++ b/MyLibrary/Sources/Safari/Safari.swift
@@ -51,3 +51,31 @@ public struct SafariViewRepresentation: UIViewControllerRepresentable {
   public func makeCoordinator() {
   }
 }
+
+public extension View {
+  func safari<T: Identifiable & Equatable, V: View>(
+    item: Binding<T?>,
+    sheetContent: @escaping (T) -> V,
+    action: @escaping (T) -> Void
+  ) -> some View {
+    self.modifier(SafariModifier(item: item, sheetContent: sheetContent, action: action))
+  }
+}
+
+struct SafariModifier<T: Identifiable & Equatable, V: View>: ViewModifier {
+  let item: Binding<T?>
+  let sheetContent: (T) -> V
+  let action: (T) -> Void
+  
+  func body(content: Content) -> some View {
+    content
+      #if os(iOS) || os(macOS)
+      .sheet(item: item, content: sheetContent)
+      #elseif os(visionOS)
+      .onChange(of: item.wrappedValue) { _, newValue in
+        guard let newValue else { return }
+        action(newValue)
+      }
+      #endif
+  }
+}

--- a/MyLibrary/Sources/ScheduleFeature/Detail.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Detail.swift
@@ -104,16 +104,20 @@ public struct ScheduleDetailView: View {
         Spacer()
       }
     }
-    .safari(
-      item: $store.scope(state: \.destination?.safari, action: \.destination.safari),
-      sheetContent: { sheetStore in
-        SafariViewRepresentation(url: sheetStore.url)
-          .ignoresSafeArea()
-      },
-      action: { store in
-        openURL(store.url)
-      }
-    )
+    #if os(iOS) || os(macOS)
+    .sheet(item: $store.scope(state: \.destination?.safari, action: \.destination.safari)) {
+      sheetStore in
+      SafariViewRepresentation(url: sheetStore.url)
+        .ignoresSafeArea()
+    }
+    #elseif os(visionOS)
+    .onChange(
+      of: store.scope(state: \.destination?.safari, action: \.destination.safari)
+    ) { _, store in
+      guard let url = store?.url else { return }
+      openURL(url)
+    }
+    #endif
   }
 
   @ViewBuilder

--- a/MyLibrary/Sources/ScheduleFeature/Detail.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Detail.swift
@@ -53,7 +53,7 @@ public struct ScheduleDetail {
         state.destination = .safari(.init(url: url))
         return .none
         #elseif os(visionOS)
-        return .run(operation: { _ in await openURL(url) })
+        return .run { _ in await openURL(url) }
         #endif
       case .destination:
         return .none

--- a/MyLibrary/Sources/ScheduleFeature/Detail.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Detail.swift
@@ -104,20 +104,16 @@ public struct ScheduleDetailView: View {
         Spacer()
       }
     }
-    #if os(iOS) || os(macOS)
-    .sheet(item: $store.scope(state: \.destination?.safari, action: \.destination.safari)) {
-      sheetStore in
-      SafariViewRepresentation(url: sheetStore.url)
-        .ignoresSafeArea()
-    }
-    #elseif os(visionOS)
-    .onChange(
-      of: store.scope(state: \.destination?.safari, action: \.destination.safari)
-    ) { _, store in
-      guard let url = store?.url else { return }
-      openURL(url)
-    }
-    #endif
+    .safari(
+      item: $store.scope(state: \.destination?.safari, action: \.destination.safari),
+      sheetContent: { sheetStore in
+        SafariViewRepresentation(url: sheetStore.url)
+          .ignoresSafeArea()
+      },
+      action: { store in
+        openURL(store.url)
+      }
+    )
   }
 
   @ViewBuilder

--- a/MyLibrary/Sources/ScheduleFeature/Detail.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Detail.swift
@@ -63,6 +63,8 @@ public struct ScheduleDetail {
 public struct ScheduleDetailView: View {
 
   @Bindable public var store: StoreOf<ScheduleDetail>
+  
+  @Environment(\.openURL) var openURL
 
   public init(store: StoreOf<ScheduleDetail>) {
     self.store = store
@@ -102,11 +104,20 @@ public struct ScheduleDetailView: View {
         Spacer()
       }
     }
+    #if os(iOS) || os(macOS)
     .sheet(item: $store.scope(state: \.destination?.safari, action: \.destination.safari)) {
       sheetStore in
       SafariViewRepresentation(url: sheetStore.url)
         .ignoresSafeArea()
     }
+    #elseif os(visionOS)
+    .onChange(
+      of: store.scope(state: \.destination?.safari, action: \.destination.safari)
+    ) { _, store in
+      guard let url = store?.url else { return }
+      openURL(url)
+    }
+    #endif
   }
 
   @ViewBuilder

--- a/MyLibrary/Sources/ScheduleFeature/Schedule.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Schedule.swift
@@ -122,20 +122,16 @@ public struct ScheduleView: View {
         }
       }
     }
-    #if os(iOS) || os(macOS)
-    .sheet(item: $store.scope(state: \.destination?.guidance, action: \.destination.guidance)) {
-      sheetStore in
-      SafariViewRepresentation(url: sheetStore.url)
-        .ignoresSafeArea()
-    }
-    #elseif os(visionOS)
-    .onChange(
-      of: store.scope(state: \.destination?.guidance, action: \.destination.guidance)
-    ) { _, store in
-      guard let url = store?.url else { return }
-      openURL(url)
-    }
-    #endif
+    .safari(
+      item: $store.scope(state: \.destination?.guidance, action: \.destination.guidance),
+      sheetContent: { sheetStore in
+        SafariViewRepresentation(url: sheetStore.url)
+          .ignoresSafeArea()
+      },
+      action: { store in
+        openURL(store.url)
+      }
+    )
   }
 
   @ViewBuilder

--- a/MyLibrary/Sources/ScheduleFeature/Schedule.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Schedule.swift
@@ -122,16 +122,20 @@ public struct ScheduleView: View {
         }
       }
     }
-    .safari(
-      item: $store.scope(state: \.destination?.guidance, action: \.destination.guidance),
-      sheetContent: { sheetStore in
-        SafariViewRepresentation(url: sheetStore.url)
-          .ignoresSafeArea()
-      },
-      action: { store in
-        openURL(store.url)
-      }
-    )
+    #if os(iOS) || os(macOS)
+    .sheet(item: $store.scope(state: \.destination?.guidance, action: \.destination.guidance)) {
+      sheetStore in
+      SafariViewRepresentation(url: sheetStore.url)
+        .ignoresSafeArea()
+    }
+    #elseif os(visionOS)
+    .onChange(
+      of: store.scope(state: \.destination?.guidance, action: \.destination.guidance)
+    ) { _, store in
+      guard let url = store?.url else { return }
+      openURL(url)
+    }
+    #endif
   }
 
   @ViewBuilder

--- a/MyLibrary/Sources/ScheduleFeature/Schedule.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Schedule.swift
@@ -102,6 +102,9 @@ public struct Schedule {
 public struct ScheduleView: View {
 
   @Bindable public var store: StoreOf<Schedule>
+  
+  @Environment(\.openURL) var openURL
+  
   let mapTip: MapTip = .init()
 
   public init(store: StoreOf<Schedule>) {
@@ -119,11 +122,20 @@ public struct ScheduleView: View {
         }
       }
     }
+    #if os(iOS) || os(macOS)
     .sheet(item: $store.scope(state: \.destination?.guidance, action: \.destination.guidance)) {
       sheetStore in
       SafariViewRepresentation(url: sheetStore.url)
         .ignoresSafeArea()
     }
+    #elseif os(visionOS)
+    .onChange(
+      of: store.scope(state: \.destination?.guidance, action: \.destination.guidance)
+    ) { _, store in
+      guard let url = store?.url else { return }
+      openURL(url)
+    }
+    #endif
   }
 
   @ViewBuilder

--- a/MyLibrary/Sources/ScheduleFeature/Schedule.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Schedule.swift
@@ -91,7 +91,7 @@ public struct Schedule {
         state.destination = .guidance(.init(url: url))
         return .none
         #elseif os(visionOS)
-        return .run(operation: { _ in await openURL(url) })
+        return .run { _ in await openURL(url) }
         #endif
       case .binding, .path, .destination:
         return .none

--- a/MyLibrary/Sources/SponsorFeature/Sponsors.swift
+++ b/MyLibrary/Sources/SponsorFeature/Sponsors.swift
@@ -44,8 +44,12 @@ public struct SponsorsList {
 
       case let .view(.sponsorTapped(sponsor)):
         guard let url = sponsor.link else { return .none }
+        #if os(iOS) || os(macOS)
         state.destination = .safari(.init(url: url))
         return .none
+        #elseif os(visionOS)
+        return .run(operation: { _ in await openURL(url) })
+        #endif
       case .binding:
         return .none
       case .destination:
@@ -64,8 +68,6 @@ public struct SponsorsList {
 @ViewAction(for: SponsorsList.self)
 public struct SponsorsListView: View {
   @Bindable public var store: StoreOf<SponsorsList>
-  
-  @Environment(\.openURL) var openURL
 
   public init(store: StoreOf<SponsorsList>) {
     self.store = store
@@ -74,21 +76,12 @@ public struct SponsorsListView: View {
   public var body: some View {
     NavigationView {
       root
-        #if os(iOS) || os(macOS)
         .fullScreenCover(
           item: $store.scope(state: \.destination?.safari, action: \.destination.safari)
         ) { sheetStore in
           SafariViewRepresentation(url: sheetStore.url)
             .ignoresSafeArea()
         }
-        #elseif os(visionOS)
-        .onChange(
-          of: store.scope(state: \.destination?.safari, action: \.destination.safari)
-        ) { _, store in
-          guard let url = store?.url else { return }
-          openURL(url)
-        }
-        #endif
         .onAppear {
           send(.onAppear)
         }

--- a/MyLibrary/Sources/SponsorFeature/Sponsors.swift
+++ b/MyLibrary/Sources/SponsorFeature/Sponsors.swift
@@ -48,7 +48,7 @@ public struct SponsorsList {
         state.destination = .safari(.init(url: url))
         return .none
         #elseif os(visionOS)
-        return .run(operation: { _ in await openURL(url) })
+        return .run { _ in await openURL(url) }
         #endif
       case .binding:
         return .none

--- a/MyLibrary/Sources/SponsorFeature/Sponsors.swift
+++ b/MyLibrary/Sources/SponsorFeature/Sponsors.swift
@@ -64,6 +64,8 @@ public struct SponsorsList {
 @ViewAction(for: SponsorsList.self)
 public struct SponsorsListView: View {
   @Bindable public var store: StoreOf<SponsorsList>
+  
+  @Environment(\.openURL) var openURL
 
   public init(store: StoreOf<SponsorsList>) {
     self.store = store
@@ -72,12 +74,21 @@ public struct SponsorsListView: View {
   public var body: some View {
     NavigationView {
       root
+        #if os(iOS) || os(macOS)
         .fullScreenCover(
           item: $store.scope(state: \.destination?.safari, action: \.destination.safari)
         ) { sheetStore in
           SafariViewRepresentation(url: sheetStore.url)
             .ignoresSafeArea()
         }
+        #elseif os(visionOS)
+        .onChange(
+          of: store.scope(state: \.destination?.safari, action: \.destination.safari)
+        ) { _, store in
+          guard let url = store?.url else { return }
+          openURL(url)
+        }
+        #endif
         .onAppear {
           send(.onAppear)
         }

--- a/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
@@ -16,13 +16,19 @@ public struct Acknowledgements {
     case urlTapped(URL)
     case safari(PresentationAction<Safari.Action>)
   }
+  
+  @Dependency(\.openURL) var openURL
 
   public var body: some ReducerOf<Self> {
     Reduce { state, action in
       switch action {
       case let .urlTapped(url):
+        #if os(iOS) || os(macOS)
         state.safari = .init(url: url)
         return .none
+        #elseif os(visionOS)
+        return .run(operation: { _ in await openURL(url) })
+        #endif
       case .safari:
         return .none
       }
@@ -36,25 +42,13 @@ public struct Acknowledgements {
 public struct AcknowledgementsView: View {
 
   @Bindable public var store: StoreOf<Acknowledgements>
-  
-  @Environment(\.openURL) var openURL
 
   public var body: some View {
     list
-      #if os(iOS) || os(macOS)
       .sheet(item: $store.scope(state: \.safari, action: \.safari)) { sheetStore in
         SafariViewRepresentation(url: sheetStore.url)
           .ignoresSafeArea()
       }
-      #elseif os(visionOS)
-      .onChange(
-        of: store.scope(state: \.safari, action: \.safari)
-      ) { _, store in
-        guard let url = store?.url else { return }
-        openURL(url)
-      }
-      #endif
-      
   }
 
   @ViewBuilder

--- a/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
@@ -41,20 +41,16 @@ public struct AcknowledgementsView: View {
 
   public var body: some View {
     list
-      #if os(iOS) || os(macOS)
-      .sheet(item: $store.scope(state: \.safari, action: \.safari)) { sheetStore in
-        SafariViewRepresentation(url: sheetStore.url)
-          .ignoresSafeArea()
-      }
-      #elseif os(visionOS)
-      .onChange(
-        of: store.scope(state: \.safari, action: \.safari)
-      ) { _, store in
-        guard let url = store?.url else { return }
-        openURL(url)
-      }
-      #endif
-      
+      .safari(
+        item: $store.scope(state: \.safari, action: \.safari),
+        sheetContent: { sheetStore in
+          SafariViewRepresentation(url: sheetStore.url)
+            .ignoresSafeArea()
+        },
+        action: { store in
+          openURL(store.url)
+        }
+      )
   }
 
   @ViewBuilder

--- a/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
@@ -41,16 +41,20 @@ public struct AcknowledgementsView: View {
 
   public var body: some View {
     list
-      .safari(
-        item: $store.scope(state: \.safari, action: \.safari),
-        sheetContent: { sheetStore in
-          SafariViewRepresentation(url: sheetStore.url)
-            .ignoresSafeArea()
-        },
-        action: { store in
-          openURL(store.url)
-        }
-      )
+      #if os(iOS) || os(macOS)
+      .sheet(item: $store.scope(state: \.safari, action: \.safari)) { sheetStore in
+        SafariViewRepresentation(url: sheetStore.url)
+          .ignoresSafeArea()
+      }
+      #elseif os(visionOS)
+      .onChange(
+        of: store.scope(state: \.safari, action: \.safari)
+      ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+      }
+      #endif
+      
   }
 
   @ViewBuilder

--- a/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
@@ -36,13 +36,25 @@ public struct Acknowledgements {
 public struct AcknowledgementsView: View {
 
   @Bindable public var store: StoreOf<Acknowledgements>
+  
+  @Environment(\.openURL) var openURL
 
   public var body: some View {
     list
+      #if os(iOS) || os(macOS)
       .sheet(item: $store.scope(state: \.safari, action: \.safari)) { sheetStore in
         SafariViewRepresentation(url: sheetStore.url)
           .ignoresSafeArea()
       }
+      #elseif os(visionOS)
+      .onChange(
+        of: store.scope(state: \.safari, action: \.safari)
+      ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+      }
+      #endif
+      
   }
 
   @ViewBuilder

--- a/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
@@ -27,7 +27,7 @@ public struct Acknowledgements {
         state.safari = .init(url: url)
         return .none
         #elseif os(visionOS)
-        return .run(operation: { _ in await openURL(url) })
+        return .run { _ in await openURL(url) }
         #endif
       case .safari:
         return .none

--- a/MyLibrary/Sources/trySwiftFeature/Profile.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Profile.swift
@@ -90,19 +90,15 @@ public struct ProfileView: View {
       }
       .navigationTitle(Text(LocalizedStringKey(store.organizer.name), bundle: .module))
     }
-    #if os(iOS) || os(macOS)
-    .sheet(item: $store.scope(state: \.destination?.safari, action: \.destination.safari)) {
-      sheetStore in
-      SafariViewRepresentation(url: sheetStore.url)
-        .ignoresSafeArea()
-    }
-    #elseif os(visionOS)
-    .onChange(
-        of: store.scope(state: \.destination?.safari, action: \.destination.safari)
-    ) { _, store in
-        guard let url = store?.url else { return }
-        openURL(url)
-    }
-    #endif
+    .safari(
+      item: $store.scope(state: \.destination?.safari, action: \.destination.safari),
+      sheetContent: { sheetStore in
+        SafariViewRepresentation(url: sheetStore.url)
+          .ignoresSafeArea()
+      },
+      action: { store in
+        openURL(store.url)
+      }
+    )
   }
 }

--- a/MyLibrary/Sources/trySwiftFeature/Profile.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Profile.swift
@@ -54,6 +54,8 @@ public struct Profile {
 public struct ProfileView: View {
 
   @Bindable public var store: StoreOf<Profile>
+    
+  @Environment(\.openURL) var openURL
 
   public init(store: StoreOf<Profile>) {
     self.store = store
@@ -88,10 +90,19 @@ public struct ProfileView: View {
       }
       .navigationTitle(Text(LocalizedStringKey(store.organizer.name), bundle: .module))
     }
+    #if os(iOS) || os(macOS)
     .sheet(item: $store.scope(state: \.destination?.safari, action: \.destination.safari)) {
       sheetStore in
       SafariViewRepresentation(url: sheetStore.url)
         .ignoresSafeArea()
     }
+    #elseif os(visionOS)
+    .onChange(
+        of: store.scope(state: \.destination?.safari, action: \.destination.safari)
+    ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+    }
+    #endif
   }
 }

--- a/MyLibrary/Sources/trySwiftFeature/Profile.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Profile.swift
@@ -44,7 +44,7 @@ public struct Profile {
         state.destination = .safari(.init(url: url))
         return .none
         #elseif os(visionOS)
-        return .run(operation: { _ in await openURL(url) })
+        return .run { _ in await openURL(url) }
         #endif
       case .destination:
         return .none

--- a/MyLibrary/Sources/trySwiftFeature/Profile.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Profile.swift
@@ -90,15 +90,19 @@ public struct ProfileView: View {
       }
       .navigationTitle(Text(LocalizedStringKey(store.organizer.name), bundle: .module))
     }
-    .safari(
-      item: $store.scope(state: \.destination?.safari, action: \.destination.safari),
-      sheetContent: { sheetStore in
-        SafariViewRepresentation(url: sheetStore.url)
-          .ignoresSafeArea()
-      },
-      action: { store in
-        openURL(store.url)
-      }
-    )
+    #if os(iOS) || os(macOS)
+    .sheet(item: $store.scope(state: \.destination?.safari, action: \.destination.safari)) {
+      sheetStore in
+      SafariViewRepresentation(url: sheetStore.url)
+        .ignoresSafeArea()
+    }
+    #elseif os(visionOS)
+    .onChange(
+        of: store.scope(state: \.destination?.safari, action: \.destination.safari)
+    ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+    }
+    #endif
   }
 }

--- a/MyLibrary/Sources/trySwiftFeature/trySwift.swift
+++ b/MyLibrary/Sources/trySwiftFeature/trySwift.swift
@@ -92,7 +92,7 @@ public struct TrySwift {
 public struct TrySwiftView: View {
 
   @Bindable public var store: StoreOf<TrySwift>
-    
+  
   @Environment(\.openURL) var openURL
 
   public init(store: StoreOf<TrySwift>) {
@@ -172,61 +172,47 @@ public struct TrySwiftView: View {
       }
     }
     .navigationTitle(Text("try! Swift", bundle: .module))
-    #if os(iOS) || os(macOS)
-    .sheet(
-      item: $store.scope(state: \.destination?.codeOfConduct, action: \.destination.codeOfConduct)
-    ) { sheetStore in
-      SafariViewRepresentation(url: sheetStore.url)
-        .ignoresSafeArea()
-        .navigationTitle(Text("Code of Conduct", bundle: .module))
-    }
-    .sheet(
+    .safari(
+      item: $store.scope(state: \.destination?.codeOfConduct, action: \.destination.codeOfConduct),
+      sheetContent: { sheetStore in
+        SafariViewRepresentation(url: sheetStore.url)
+          .ignoresSafeArea()
+          .navigationTitle(Text("Code of Conduct", bundle: .module))
+      },
+      action: { store in
+        openURL(store.url)
+      }
+    )
+    .safari(
       item: $store.scope(state: \.destination?.privacyPolicy, action: \.destination.privacyPolicy),
-      content: { sheetStore in
+      sheetContent: { sheetStore in
         SafariViewRepresentation(url: sheetStore.url)
           .ignoresSafeArea()
           .navigationTitle(Text("Privacy Policy", bundle: .module))
+      },
+      action: { store in
+        openURL(store.url)
       }
     )
-    .sheet(
+    .safari(
       item: $store.scope(state: \.destination?.eventbrite, action: \.destination.eventbrite),
-      content: { sheetStore in
+      sheetContent: { sheetStore in
         SafariViewRepresentation(url: sheetStore.url)
           .ignoresSafeArea()
+      },
+      action: { store in
+        openURL(store.url)
       }
     )
-    .sheet(
+    .safari(
       item: $store.scope(state: \.destination?.website, action: \.destination.website),
-      content: { sheetStore in
+      sheetContent: { sheetStore in
         SafariViewRepresentation(url: sheetStore.url)
           .ignoresSafeArea()
+      },
+      action: { store in
+        openURL(store.url)
       }
     )
-    #elseif os(visionOS)
-    .onChange(
-        of: store.scope(state: \.destination?.codeOfConduct, action: \.destination.codeOfConduct)
-    ) { _, store in
-        guard let url = store?.url else { return }
-        openURL(url)
-    }
-    .onChange(
-        of: store.scope(state: \.destination?.privacyPolicy, action: \.destination.privacyPolicy)
-    ) { _, store in
-        guard let url = store?.url else { return }
-        openURL(url)
-    }
-    .onChange(
-        of: store.scope(state: \.destination?.eventbrite, action: \.destination.eventbrite)
-    ) { _, store in
-        guard let url = store?.url else { return }
-        openURL(url)
-    }
-    .onChange(
-        of: store.scope(state: \.destination?.website, action: \.destination.website)
-    ) { _, store in
-        guard let url = store?.url else { return }
-        openURL(url)
-    }
-    #endif
   }
 }

--- a/MyLibrary/Sources/trySwiftFeature/trySwift.swift
+++ b/MyLibrary/Sources/trySwiftFeature/trySwift.swift
@@ -92,7 +92,7 @@ public struct TrySwift {
 public struct TrySwiftView: View {
 
   @Bindable public var store: StoreOf<TrySwift>
-  
+    
   @Environment(\.openURL) var openURL
 
   public init(store: StoreOf<TrySwift>) {
@@ -172,47 +172,61 @@ public struct TrySwiftView: View {
       }
     }
     .navigationTitle(Text("try! Swift", bundle: .module))
-    .safari(
-      item: $store.scope(state: \.destination?.codeOfConduct, action: \.destination.codeOfConduct),
-      sheetContent: { sheetStore in
-        SafariViewRepresentation(url: sheetStore.url)
-          .ignoresSafeArea()
-          .navigationTitle(Text("Code of Conduct", bundle: .module))
-      },
-      action: { store in
-        openURL(store.url)
-      }
-    )
-    .safari(
+    #if os(iOS) || os(macOS)
+    .sheet(
+      item: $store.scope(state: \.destination?.codeOfConduct, action: \.destination.codeOfConduct)
+    ) { sheetStore in
+      SafariViewRepresentation(url: sheetStore.url)
+        .ignoresSafeArea()
+        .navigationTitle(Text("Code of Conduct", bundle: .module))
+    }
+    .sheet(
       item: $store.scope(state: \.destination?.privacyPolicy, action: \.destination.privacyPolicy),
-      sheetContent: { sheetStore in
+      content: { sheetStore in
         SafariViewRepresentation(url: sheetStore.url)
           .ignoresSafeArea()
           .navigationTitle(Text("Privacy Policy", bundle: .module))
-      },
-      action: { store in
-        openURL(store.url)
       }
     )
-    .safari(
+    .sheet(
       item: $store.scope(state: \.destination?.eventbrite, action: \.destination.eventbrite),
-      sheetContent: { sheetStore in
+      content: { sheetStore in
         SafariViewRepresentation(url: sheetStore.url)
           .ignoresSafeArea()
-      },
-      action: { store in
-        openURL(store.url)
       }
     )
-    .safari(
+    .sheet(
       item: $store.scope(state: \.destination?.website, action: \.destination.website),
-      sheetContent: { sheetStore in
+      content: { sheetStore in
         SafariViewRepresentation(url: sheetStore.url)
           .ignoresSafeArea()
-      },
-      action: { store in
-        openURL(store.url)
       }
     )
+    #elseif os(visionOS)
+    .onChange(
+        of: store.scope(state: \.destination?.codeOfConduct, action: \.destination.codeOfConduct)
+    ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+    }
+    .onChange(
+        of: store.scope(state: \.destination?.privacyPolicy, action: \.destination.privacyPolicy)
+    ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+    }
+    .onChange(
+        of: store.scope(state: \.destination?.eventbrite, action: \.destination.eventbrite)
+    ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+    }
+    .onChange(
+        of: store.scope(state: \.destination?.website, action: \.destination.website)
+    ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+    }
+    #endif
   }
 }

--- a/MyLibrary/Sources/trySwiftFeature/trySwift.swift
+++ b/MyLibrary/Sources/trySwiftFeature/trySwift.swift
@@ -38,10 +38,7 @@ public struct TrySwift {
 
   @Reducer(state: .equatable)
   public enum Destination {
-    case codeOfConduct(Safari)
-    case privacyPolicy(Safari)
-    case eventbrite(Safari)
-    case website(Safari)
+    case safari(Safari)
   }
 
   public init() {}
@@ -55,22 +52,22 @@ public struct TrySwift {
         return .none
       case .view(.codeOfConductTapped):
         let url = URL(string: String(localized: "Code of Conduct URL", bundle: .module))!
-        state.destination = .codeOfConduct(.init(url: url))
+        state.destination = .safari(.init(url: url))
         return .none
       case .view(.privacyPolicyTapped):
         let url = URL(string: String(localized: "Privacy Policy URL", bundle: .module))!
-        state.destination = .privacyPolicy(.init(url: url))
+        state.destination = .safari(.init(url: url))
         return .none
       case .view(.acknowledgementsTapped):
         state.path.append(.acknowledgements(.init()))
         return .none
       case .view(.eventbriteTapped):
         let url = URL(string: String(localized: "Eventbrite URL", bundle: .module))!
-        state.destination = .eventbrite(.init(url: url))
+        state.destination = .safari(.init(url: url))
         return .none
       case .view(.websiteTapped):
         let url = URL(string: String(localized: "Website URL", bundle: .module))!
-        state.destination = .eventbrite(.init(url: url))
+        state.destination = .safari(.init(url: url))
         return .none
       case let .path(.element(_, .organizers(.delegate(.organizerTapped(organizer))))):
         state.path.append(.profile(.init(organizer: organizer)))
@@ -174,55 +171,14 @@ public struct TrySwiftView: View {
     .navigationTitle(Text("try! Swift", bundle: .module))
     #if os(iOS) || os(macOS)
     .sheet(
-      item: $store.scope(state: \.destination?.codeOfConduct, action: \.destination.codeOfConduct)
+      item: $store.scope(state: \.destination?.safari, action: \.destination.safari)
     ) { sheetStore in
       SafariViewRepresentation(url: sheetStore.url)
         .ignoresSafeArea()
-        .navigationTitle(Text("Code of Conduct", bundle: .module))
     }
-    .sheet(
-      item: $store.scope(state: \.destination?.privacyPolicy, action: \.destination.privacyPolicy),
-      content: { sheetStore in
-        SafariViewRepresentation(url: sheetStore.url)
-          .ignoresSafeArea()
-          .navigationTitle(Text("Privacy Policy", bundle: .module))
-      }
-    )
-    .sheet(
-      item: $store.scope(state: \.destination?.eventbrite, action: \.destination.eventbrite),
-      content: { sheetStore in
-        SafariViewRepresentation(url: sheetStore.url)
-          .ignoresSafeArea()
-      }
-    )
-    .sheet(
-      item: $store.scope(state: \.destination?.website, action: \.destination.website),
-      content: { sheetStore in
-        SafariViewRepresentation(url: sheetStore.url)
-          .ignoresSafeArea()
-      }
-    )
     #elseif os(visionOS)
     .onChange(
-        of: store.scope(state: \.destination?.codeOfConduct, action: \.destination.codeOfConduct)
-    ) { _, store in
-        guard let url = store?.url else { return }
-        openURL(url)
-    }
-    .onChange(
-        of: store.scope(state: \.destination?.privacyPolicy, action: \.destination.privacyPolicy)
-    ) { _, store in
-        guard let url = store?.url else { return }
-        openURL(url)
-    }
-    .onChange(
-        of: store.scope(state: \.destination?.eventbrite, action: \.destination.eventbrite)
-    ) { _, store in
-        guard let url = store?.url else { return }
-        openURL(url)
-    }
-    .onChange(
-        of: store.scope(state: \.destination?.website, action: \.destination.website)
+        of: store.scope(state: \.destination?.safari, action: \.destination.safari)
     ) { _, store in
         guard let url = store?.url else { return }
         openURL(url)

--- a/MyLibrary/Sources/trySwiftFeature/trySwift.swift
+++ b/MyLibrary/Sources/trySwiftFeature/trySwift.swift
@@ -58,7 +58,7 @@ public struct TrySwift {
         state.destination = .safari(.init(url: url))
         return .none
         #elseif os(visionOS)
-        return .run(operation: { _ in await openURL(url) })
+        return .run { _ in await openURL(url) }
         #endif
       case .view(.privacyPolicyTapped):
         let url = URL(string: String(localized: "Privacy Policy URL", bundle: .module))!
@@ -66,7 +66,7 @@ public struct TrySwift {
         state.destination = .safari(.init(url: url))
         return .none
         #elseif os(visionOS)
-        return .run(operation: { _ in await openURL(url) })
+        return .run { _ in await openURL(url) }
         #endif
       case .view(.acknowledgementsTapped):
         state.path.append(.acknowledgements(.init()))
@@ -77,7 +77,7 @@ public struct TrySwift {
         state.destination = .safari(.init(url: url))
         return .none
         #elseif os(visionOS)
-        return .run(operation: { _ in await openURL(url) })
+        return .run { _ in await openURL(url) }
         #endif
       case .view(.websiteTapped):
         let url = URL(string: String(localized: "Website URL", bundle: .module))!
@@ -85,7 +85,7 @@ public struct TrySwift {
         state.destination = .safari(.init(url: url))
         return .none
         #elseif os(visionOS)
-        return .run(operation: { _ in await openURL(url) })
+        return .run { _ in await openURL(url) }
         #endif
       case let .path(.element(_, .organizers(.delegate(.organizerTapped(organizer))))):
         state.path.append(.profile(.init(organizer: organizer)))

--- a/MyLibrary/Sources/trySwiftFeature/trySwift.swift
+++ b/MyLibrary/Sources/trySwiftFeature/trySwift.swift
@@ -92,6 +92,8 @@ public struct TrySwift {
 public struct TrySwiftView: View {
 
   @Bindable public var store: StoreOf<TrySwift>
+    
+  @Environment(\.openURL) var openURL
 
   public init(store: StoreOf<TrySwift>) {
     self.store = store
@@ -170,6 +172,7 @@ public struct TrySwiftView: View {
       }
     }
     .navigationTitle(Text("try! Swift", bundle: .module))
+    #if os(iOS) || os(macOS)
     .sheet(
       item: $store.scope(state: \.destination?.codeOfConduct, action: \.destination.codeOfConduct)
     ) { sheetStore in
@@ -197,6 +200,33 @@ public struct TrySwiftView: View {
       content: { sheetStore in
         SafariViewRepresentation(url: sheetStore.url)
           .ignoresSafeArea()
-      })
+      }
+    )
+    #elseif os(visionOS)
+    .onChange(
+        of: store.scope(state: \.destination?.codeOfConduct, action: \.destination.codeOfConduct)
+    ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+    }
+    .onChange(
+        of: store.scope(state: \.destination?.privacyPolicy, action: \.destination.privacyPolicy)
+    ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+    }
+    .onChange(
+        of: store.scope(state: \.destination?.eventbrite, action: \.destination.eventbrite)
+    ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+    }
+    .onChange(
+        of: store.scope(state: \.destination?.website, action: \.destination.website)
+    ) { _, store in
+        guard let url = store?.url else { return }
+        openURL(url)
+    }
+    #endif
   }
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We've submitted the app to the App Store as MVP, and it's currently under review
 - [ ] macOS support
 - [ ] watchOS support
 - [ ] tvOS support
-- [x] visionOS support (Designed for iPad)
+- [x] visionOS support
 
 ## Requirements
 


### PR DESCRIPTION
# Changes

- Removed Apple Vision (Designed for iPad) target.
- Added Apple Vision (visionOS SDK) target.
- Edited embed Clip filter
  - `Allow any platform` to `iOS and macOS`
- Added visionOS platform to Package.swift
- Browser support

![Simulator Screenshot - Apple Vision Pro - 2024-03-13 at 20 34 00](https://github.com/tryswift/trySwiftTokyoApp/assets/2066707/618d4003-9fc2-4ea3-abf1-1738985cc007)
