### PR TITLE
Fix translation of Yunosuke Sakai's description

### DIFF
--- a/MyLibrary/Sources/ScheduleFeature/Localizable.xcstrings
+++ b/MyLibrary/Sources/ScheduleFeature/Localizable.xcstrings
@@ -490,7 +490,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "I like ramen."
+            "value" : "美しい映画、小説、写真、モバイルアプリが好きです"
           }
         }
       }


### PR DESCRIPTION
## Background
- It seems that there is a localization mistake for Yunosuke Sakai's profile description 👀 

| English 🆗 | Japanese 🍜 |
| - | - |
| ![Simulator Screenshot - iPhone 15 - 2024-03-14 at 12 21 19](https://github.com/tryswift/trySwiftTokyoApp/assets/37182704/c6a0cfcd-dd5e-4dcc-894a-3d30cf426ead) | ![Simulator Screenshot - iPhone 15 - 2024-03-14 at 12 20 43](https://github.com/tryswift/trySwiftTokyoApp/assets/37182704/90746c5c-b333-4728-bd5b-57d55454da98) |


## Changes
- Updated translation
- I copied the text from https://tryswift.jp/#speaker

<img src="https://github.com/tryswift/trySwiftTokyoApp/assets/37182704/1217def6-2a67-43c4-8e0c-178da9b303f5" width="50%">
