### PR TITLE
Fix a truncated session title in Japanese

### DIFF
--- a/MyLibrary/Sources/ScheduleFeature/Detail.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Detail.swift
@@ -82,6 +82,7 @@ public struct ScheduleDetailView: View {
           VStack(alignment: .leading, spacing: 16) {
             Text(LocalizedStringKey(store.title), bundle: .module)
               .font(.title.bold())
+              .fixedSize(horizontal: false, vertical: true)
             Text(LocalizedStringKey(store.description), bundle: .module)
               .font(.callout)
             if let requirements = store.requirements {

--- a/MyLibrary/Sources/ScheduleFeature/Detail.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Detail.swift
@@ -76,38 +76,32 @@ public struct ScheduleDetailView: View {
 
   public var body: some View {
     ScrollView {
-      HStack {
-        Spacer()
-        VStack {
-          VStack(alignment: .leading, spacing: 16) {
-            Text(LocalizedStringKey(store.title), bundle: .module)
-              .font(.title.bold())
-              .fixedSize(horizontal: false, vertical: true)
-            Text(LocalizedStringKey(store.description), bundle: .module)
+      VStack(alignment: .leading, spacing: 16) {
+        Text(LocalizedStringKey(store.title), bundle: .module)
+          .font(.title.bold())
+        Text(LocalizedStringKey(store.description), bundle: .module)
+          .font(.callout)
+        if let requirements = store.requirements {
+          VStack(alignment: .leading) {
+            Text("Requirements", bundle: .module)
+              .font(.subheadline.bold())
+              .foregroundStyle(Color.accentColor)
+            Text(LocalizedStringKey(requirements), bundle: .module)
               .font(.callout)
-            if let requirements = store.requirements {
-              VStack(alignment: .leading) {
-                Text("Requirements", bundle: .module)
-                  .font(.subheadline.bold())
-                  .foregroundStyle(Color.accentColor)
-                Text(LocalizedStringKey(requirements), bundle: .module)
-                  .font(.callout)
-              }
-              .padding()
-              .overlay {
-                RoundedRectangle(cornerRadius: 16)
-                  .stroke(Color.accentColor, lineWidth: 1)
-              }
-            }
           }
-          .padding(.horizontal)
-          .padding(.bottom)
-          .frame(maxWidth: 700)  // Readable content width for iPad
-          speakers
-            .frame(maxWidth: 700)  // Readable content width for iPad
+          .padding()
+          .overlay {
+            RoundedRectangle(cornerRadius: 16)
+              .stroke(Color.accentColor, lineWidth: 1)
+          }
         }
-        Spacer()
       }
+      .padding(.horizontal)
+      .padding(.bottom)
+      .frame(maxWidth: 700)  // Readable content width for iPad
+
+      speakers
+        .frame(maxWidth: 700)  // Readable content width for iPad
     }
     .sheet(item: $store.scope(state: \.destination?.safari, action: \.destination.safari)) {
       sheetStore in


### PR DESCRIPTION
## Result

|Current|This PR|
|---|---|
|<img width="308" alt="Screenshot 2024-03-14 at 21 53 20" src="https://github.com/tryswift/trySwiftTokyoApp/assets/15936908/3440c1b3-014b-425b-909e-1e2eb16a1205">|<img width="308" alt="Screenshot 2024-03-14 at 22 14 18" src="https://github.com/tryswift/trySwiftTokyoApp/assets/15936908/37c1e471-ae7f-4a65-8032-fed8a65881aa">|

## WHY

- I found a truncated title in Japanese.
  - I checked this in real device (iPhone 13 mini) too.

## WHAT

- Use `fixedSize()` modifier.
  - https://developer.apple.com/documentation/swiftui/view/fixedsize(horizontal:vertical:)
- In this case, we didn't want the horizontal direction to exceed the screen width, so fixed the vertical direction.