### PR TITLE
Delete unnecessary padding

### DIFF
--- a/MyLibrary/Sources/ScheduleFeature/Detail.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Detail.swift
@@ -154,8 +154,6 @@ public struct ScheduleDetailView: View {
       Color(uiColor: .secondarySystemBackground)
         .clipShape(RoundedRectangle(cornerRadius: 8))
     )
-    .padding()
-
   }
 }
 


### PR DESCRIPTION
| current | this PR  | 
|---|---|
|  <img width="534" alt="Screenshot 2024-03-15 at 12 58 53" src="https://github.com/tryswift/trySwiftTokyoApp/assets/19767846/faba8f49-5998-40bb-a373-3e49abed81f7"> | <img width="534" alt="Screenshot 2024-03-15 at 13 03 19" src="https://github.com/tryswift/trySwiftTokyoApp/assets/19767846/7ea7a4ce-eb51-484e-9977-a67a0d47d073">  | 

And the picture used in App Store is also truncated, please have a check 
<img width="1469" alt="Screenshot 2024-03-15 at 13 08 17" src="https://github.com/tryswift/trySwiftTokyoApp/assets/19767846/342d11f8-adc2-491d-b0b6-fb950eb7918c">
