### PR TITLE
Solved the problem of lunch not being translated into Japanese.

### DIFF
--- a/MyLibrary/Sources/ScheduleFeature/Localizable.xcstrings
+++ b/MyLibrary/Sources/ScheduleFeature/Localizable.xcstrings
@@ -1022,7 +1022,7 @@
         }
       }
     },
-    "Take a lunch box and meet other attendees or sponsors" : {
+    "Take a lunch box and meet other attendees or sponsors." : {
       "extractionState" : "manual",
       "localizations" : {
         "ja" : {


### PR DESCRIPTION
# OverView
Problem solved where the summary of "Lunch" was not translated into Japanese.

## Screenshot

| Before | After |
----|----
| <img src="https://github.com/tryswift/trySwiftTokyoApp/assets/70003919/45ca14ca-9897-4f29-bef8-a4df276f4172" width=300> | <img src="https://github.com/tryswift/trySwiftTokyoApp/assets/70003919/0b08dc06-9b97-43f5-8336-22ff85bcc4a5" width=300>

