### PR TITLE
Add check favorite session feature in ShceduleView

### DIFF
--- a/MyLibrary/Sources/DataClient/Client.swift
+++ b/MyLibrary/Sources/DataClient/Client.swift
@@ -10,23 +10,29 @@ public struct DataClient {
   public var fetchWorkshop: @Sendable () throws -> Conference
   public var fetchSponsors: @Sendable () throws -> Sponsors
   public var fetchOrganizers: @Sendable () throws -> [Organizer]
+  public var saveDay1: @Sendable (Conference) throws -> Void
+  public var saveDay2: @Sendable (Conference) throws -> Void
+  public var saveWorkshop: @Sendable (Conference) throws -> Void
 }
 
 extension DataClient: DependencyKey {
+  private static let day1 = "day1"
+  private static let day2 = "day2"
+  private static let workshop = "workshop"
 
   static public var liveValue: DataClient = .init(
     fetchDay1: {
-      let data = loadDataFromBundle(fileName: "day1")
+      let data = loadData(dayOf: day1)
       let response = try jsonDecoder.decode(Conference.self, from: data)
       return response
     },
     fetchDay2: {
-      let data = loadDataFromBundle(fileName: "day2")
+      let data = loadData(dayOf: day2)
       let response = try jsonDecoder.decode(Conference.self, from: data)
       return response
     },
     fetchWorkshop: {
-      let data = loadDataFromBundle(fileName: "workshop")
+      let data = loadData(dayOf: workshop)
       let response = try jsonDecoder.decode(Conference.self, from: data)
       return response
     },
@@ -39,14 +45,39 @@ extension DataClient: DependencyKey {
       let data = loadDataFromBundle(fileName: "organizers")
       let response = try jsonDecoder.decode([Organizer].self, from: data)
       return response
+    },
+    saveDay1: { conference in
+      saveDataToUserDefaults(conference, as: day1)
+    },
+    saveDay2: { conference in
+      saveDataToUserDefaults(conference, as: day2)
+    },
+    saveWorkshop: { conference in
+      saveDataToUserDefaults(conference, as: workshop)
     }
   )
+
+  static func loadData(dayOf day: String) -> Data {
+    if let saveData = loadDataFromUserDefaults(key: day) {
+      return saveData
+    }
+    return loadDataFromBundle(fileName: day)
+  }
 
   static func loadDataFromBundle(fileName: String) -> Data {
     let filePath = Bundle.module.path(forResource: fileName, ofType: "json")!
     let fileURL = URL(fileURLWithPath: filePath)
     let data = try! Data(contentsOf: fileURL)
     return data
+  }
+
+  static func saveDataToUserDefaults(_ conference : Conference, as key: String) {
+    let data = try? jsonEncoder.encode(conference)
+    UserDefaults.standard.set(data, forKey: key)
+  }
+
+  static func loadDataFromUserDefaults(key: String) -> Data? {
+    return UserDefaults.standard.data(forKey: key)
   }
 }
 
@@ -55,3 +86,9 @@ let jsonDecoder = {
   $0.keyDecodingStrategy = .convertFromSnakeCase
   return $0
 }(JSONDecoder())
+
+let jsonEncoder = {
+  $0.dateEncodingStrategy = .iso8601
+  $0.keyEncodingStrategy = .convertToSnakeCase
+  return $0
+}(JSONEncoder())

--- a/MyLibrary/Sources/ScheduleFeature/Schedule.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Schedule.swift
@@ -103,7 +103,14 @@ public struct Schedule {
         case .day3:
           state.workshop = update(state.workshop!, togglingFavoriteOf: session)
         }
-        return .none
+        let day1 = state.day1!
+        let day2 = state.day2!
+        let workshop = state.workshop!
+        return .run { _ in
+          try? dataClient.saveDay1(day1)
+          try? dataClient.saveDay2(day2)
+          try? dataClient.saveWorkshop(workshop)
+        }
       case .binding, .path, .destination:
         return .none
       }

--- a/MyLibrary/Sources/ScheduleFeature/Schedule.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Schedule.swift
@@ -95,6 +95,14 @@ public struct Schedule {
           return .run { _ in await openURL(url) }
         #endif
       case let .view(.favoriteIconTapped(session)):
+        switch state.selectedDay {
+        case .day1:
+          state.day1 = update(state.day1!, togglingFavoriteOf: session)
+        case .day2:
+          state.day2 = update(state.day2!, togglingFavoriteOf: session)
+        case .day3:
+          state.workshop = update(state.workshop!, togglingFavoriteOf: session)
+        }
         return .none
       case .binding, .path, .destination:
         return .none
@@ -102,6 +110,12 @@ public struct Schedule {
     }
     .forEach(\.path, action: \.path)
     .ifLet(\.$destination, action: \.destination)
+  }
+
+  private func update(_ conference: Conference, togglingFavoriteOf session: Session) -> Conference {
+    var newValue = conference
+    newValue.toggleFavorite(of: session)
+    return newValue
   }
 }
 

--- a/MyLibrary/Sources/ScheduleFeature/Schedule.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Schedule.swift
@@ -266,6 +266,9 @@ public struct ScheduleView: View {
         }
       }
       .frame(maxWidth: .infinity, alignment: .leading)
+
+      Image(systemName: "star")
+        .foregroundColor(.gray)
     }
   }
 

--- a/MyLibrary/Sources/ScheduleFeature/Schedule.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Schedule.swift
@@ -43,6 +43,7 @@ public struct Schedule {
       case onAppear
       case disclosureTapped(Session)
       case mapItemTapped
+      case favoriteIconTapped(Session)
     }
   }
 
@@ -93,6 +94,8 @@ public struct Schedule {
         #elseif os(visionOS)
           return .run { _ in await openURL(url) }
         #endif
+      case let .view(.favoriteIconTapped(session)):
+        return .none
       case .binding, .path, .destination:
         return .none
       }
@@ -268,6 +271,9 @@ public struct ScheduleView: View {
       .frame(maxWidth: .infinity, alignment: .leading)
 
       favoriteIcon(for: session)
+        .onTapGesture {
+          send(.favoriteIconTapped(session))
+        }
     }
   }
 

--- a/MyLibrary/Sources/ScheduleFeature/Schedule.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Schedule.swift
@@ -267,6 +267,16 @@ public struct ScheduleView: View {
       }
       .frame(maxWidth: .infinity, alignment: .leading)
 
+      favoriteIcon(for: session)
+    }
+  }
+
+  @ViewBuilder
+  func favoriteIcon(for session: Session) -> some View {
+    if let isFavorited = session.isFavorited, isFavorited {
+      Image(systemName: "star.fill")
+        .foregroundColor(.yellow)
+    } else {
       Image(systemName: "star")
         .foregroundColor(.gray)
     }

--- a/MyLibrary/Sources/SharedModels/Conference.swift
+++ b/MyLibrary/Sources/SharedModels/Conference.swift
@@ -10,6 +10,12 @@ public struct Conference: Codable, Equatable, Hashable, Sendable {
     self.date = date
     self.schedules = schedules
   }
+
+  public mutating func toggleFavorite(of session: Session) {
+    for index in schedules.indices {
+      schedules[index].toggleFavorite(of: session)
+    }
+  }
 }
 
 public struct Schedule: Codable, Equatable, Hashable, Sendable {
@@ -19,6 +25,12 @@ public struct Schedule: Codable, Equatable, Hashable, Sendable {
   public init(time: Date, sessions: [Session]) {
     self.time = time
     self.sessions = sessions
+  }
+
+  mutating func toggleFavorite(of session: Session) {
+    for index in sessions.indices {
+      sessions[index].toggleFavoriteIfEqual(with: session)
+    }
   }
 }
 
@@ -40,5 +52,15 @@ public struct Session: Codable, Equatable, Hashable, Sendable {
     self.place = place
     self.description = description
     self.requirements = requirements
+  }
+
+  mutating func toggleFavoriteIfEqual(with session: Session) {
+    if self == session {
+      if let isFavorited = isFavorited, isFavorited {
+        self.isFavorited = false
+      } else {
+        self.isFavorited = true
+      }
+    }
   }
 }

--- a/MyLibrary/Sources/SharedModels/Conference.swift
+++ b/MyLibrary/Sources/SharedModels/Conference.swift
@@ -29,6 +29,7 @@ public struct Session: Codable, Equatable, Hashable, Sendable {
   public var place: String?
   public var description: String?
   public var requirements: String?
+  public var isFavorited: Bool?
 
   public init(
     title: String, speakers: [Speaker]?, place: String?, description: String?,


### PR DESCRIPTION
Add check favorite session feature as below.
> Only in ShceduleView, show star icons on the right inside of session row, toggle when the icons are tapped, and persist favorited states.

Ref: #40 

### Note
- persist `Conference` including favorited state using UserDefaults as Json files, in save methods of `DataClient`
- when app launch, try to load `Conference` from UserDefaults, and if failed then load from files in Resources