### PR TITLE
Fix alignment for multi-line speaker name

### DIFF
--- a/MyLibrary/Sources/ScheduleFeature/Schedule.swift
+++ b/MyLibrary/Sources/ScheduleFeature/Schedule.swift
@@ -245,6 +245,7 @@ public struct ScheduleView: View {
         if let speakers = session.speakers {
           Text(ListFormatter.localizedString(byJoining: speakers.map(\.name)))
             .foregroundStyle(Color.init(uiColor: .label))
+            .multilineTextAlignment(.leading)
         }
         if let summary = session.summary {
           if session.title == "Office hour", let speakers = session.speakers {


### PR DESCRIPTION
This PR fixes alignment for multi-line speaker name on ScheduleView.

### difference
| | Before | After |
|:---|:---:|:---:|
| iPhoneSE gen3* | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-03-20 at 07 48 00](https://github.com/tryswift/trySwiftTokyoApp/assets/40351476/62242814-8d70-4ea9-95b3-33152b8153e8) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-03-20 at 07 48 26](https://github.com/tryswift/trySwiftTokyoApp/assets/40351476/6f659ee5-ae99-4fd5-8c15-c20b19970a55) |
| iPhone15* | ![Simulator Screenshot - iPhone 15 - 2024-03-20 at 08 04 10](https://github.com/tryswift/trySwiftTokyoApp/assets/40351476/7b41e190-5862-4f85-8f03-79e46d496be3) | ![Simulator Screenshot - iPhone 15 - 2024-03-20 at 08 04 34](https://github.com/tryswift/trySwiftTokyoApp/assets/40351476/45a578ab-13f7-491f-ac9f-4cc059861bf1) |

*iOS 17.4