### PR TITLE
:sparkles: Explicitly specify macos-15 for GitHub Actions runner

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -25,7 +25,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-latest
+    runs-on: macos-15
     env:
       DEVELOPER_DIR: /Applications/Xcode.app
     steps:


### PR DESCRIPTION
This PR updates the runs-on specification in our GitHub Actions workflow from `macos-latest` to `macos-15` to ensure compatibility with Swift 6.

# Reason for Change:
- The [Ignite](https://github.com/twostraws/Ignite) module, which is integrated into the Website module, requires swift-tools-version: 6.0.
- Currently, `macos-latest` resolves to `macos-14`, which does not support Swift 6.
- To enable Swift 6 execution, we need to explicitly specify `macos-15` as the runner environment.

ref: https://github.com/tryswift/trySwiftTokyoApp/actions/runs/13632593576/job/38103551240