### PR TITLE
:bug: Fix Actions failure for deploying the website

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -39,6 +39,9 @@ jobs:
           restore-keys: xcode-${{ runner.os }}-
           path: ~/DerivedData/SourcePackages
 
+      - name: Skip Macro Fingerprint Validation
+        run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+
       - name: Build Website scheme
         # https://forums.swift.org/t/xcode-and-swift-package-manager/44704/7
         run: |

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './Build'
+          path: './Website/Build'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
# Reason for Change:
- As a warning was received to enable macros in [Actions #2](https://github.com/tryswift/trySwiftTokyoApp/actions/runs/13634239269/job/38108941224), I added a step to skip Macro Fingerprint Validation in https://github.com/tryswift/trySwiftTokyoApp/commit/ce142c719c9250eef2f15020f6acd13fda1fe69d .
- While verifying the GitHub Actions workflow on the forked repository, I found a mistake in the path specification, which I fixed in https://github.com/tryswift/trySwiftTokyoApp/commit/6a86c4b346021bdffaf34d6568ea855335e864c3 .

This branch has already been verified and confirmed to work properly with the pre-deployment check in [this run](https://github.com/AkkeyLab/trySwiftTokyoApp/actions/runs/13636414385/job/38116221515).  
I’d like to first apologize for the previous oversight of not verifying the Actions workflow on GitHub beforehand. Lastly, thank you very much for your understanding and support!