### PR TITLE
:bug: Fix individual sponsor image links and update Actions trigger paths

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -9,6 +9,9 @@ on:
       - "Website/Assets/**"
       - "trySwiftTokyo.xcworkspace/xcshareddata/swiftpm/Package.resolved"
       - ".github/workflows/deploy_website.yml"
+      - "MyLibrary/Sources/SponsorFeature/Media.xcassets/**"
+      - "MyLibrary/Sources/ScheduleFeature/Media.xcassets/**"
+      - "MyLibrary/Sources/DataClient/Resources/**"
   workflow_dispatch:
 
 permissions:

--- a/MyLibrary/Sources/DataClient/Resources/sponsors.json
+++ b/MyLibrary/Sources/DataClient/Resources/sponsors.json
@@ -217,7 +217,7 @@
   "individual": [
     {
       "id": 1,
-      "imageName": "Individual_ooba",
+      "imageName": "individual_ooba",
       "link": "https://x.com/ooba"
     },
     {
@@ -227,72 +227,72 @@
     },
     {
       "id": 4,
-      "imageName": "Individual_shiz",
+      "imageName": "individual_shiz",
       "link": "https://x.com/stzn3"
     },
     {
       "id": 5,
-      "imageName": "Individual_noppe",
+      "imageName": "individual_noppe",
       "link": "https://github.com/noppefoxwolf"
     },
     {
       "id": 6,
-      "imageName": "Individual_arasan01",
+      "imageName": "individual_arasan01",
       "link": "https://x.com/arasan01_me"
     },
     {
       "id": 7,
-      "imageName": "Individual_banjun",
+      "imageName": "individual_banjun",
       "link": "https://github.com/banjun"
     },
     {
       "id": 9,
-      "imageName": "Individual_hcrane",
+      "imageName": "individual_hcrane",
       "link": "https://x.com/hcrane14"
     },
     {
       "id": 11,
-      "imageName": "Individual_yuji_fujisaka",
+      "imageName": "individual_yuji_fujisaka",
       "link": "https://github.com/yujif"
     },
     {
       "id": 16,
-      "imageName": "Individual_tamadeveloper",
+      "imageName": "individual_tamadeveloper",
       "link": "https://x.com/tamadeveloper/"
     },
     {
       "id": 17,
-      "imageName": "Individual_econa77",
+      "imageName": "individual_econa77",
       "link": "https://github.com/Econa77"
     },
     {
       "id": 19,
-      "imageName": "Individual_scenee",
+      "imageName": "individual_scenee",
       "link": "https://scenee.com/"
     },
     {
       "id": 20,
-      "imageName": "Individual_aaron",
+      "imageName": "individual_aaron",
       "link": "https://github.com/apparition47"
     },
     {
       "id": 21,
-      "imageName": "Individual_sean_labastille",
+      "imageName": "individual_sean_labastille",
       "link": "https://mastodon.online/@flufff42"
     },
     {
       "id": 22,
-      "imageName": "Individual_nao",
+      "imageName": "individual_nao",
       "link": "https://www.naoenomoto.com/"
     },
     {
       "id": 23,
-      "imageName": "Individual_shogo4405",
+      "imageName": "individual_shogo4405",
       "link": "https://github.com/shogo4405"
     },
     {
       "id": 25,
-      "imageName": "Individual_justin",
+      "imageName": "individual_justin",
       "link": "https://littlebobert.github.io/"
     }
   ]


### PR DESCRIPTION
 # Reason for Change:
- Fixed incorrect image links for individual sponsors.
  - Specifically, the issue was caused by the uppercase “I” in “Individual,” which has now been standardized to lowercase.
- Updated GitHub Actions to trigger when changes are made to additional resource directories.
  - The workflow for deploying the website now runs when modifications are made to the following directories:
    - MyLibrary/Sources/SponsorFeature/Media.xcassets
    - MyLibrary/Sources/ScheduleFeature/Media.xcassets
    - MyLibrary/Sources/DataClient/Resources